### PR TITLE
Adds SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION api to dash_underlay_routing

### DIFF
--- a/dash-pipeline/bmv2/underlay.p4
+++ b/dash-pipeline/bmv2/underlay.p4
@@ -2,6 +2,11 @@
 #include "dash_headers.p4"
 #include "dash_metadata.p4"
 
+// The values in this context have been sourced from the 'saiswitch.h' file and 
+// have been manually designated to maintain alignment with enum values specified in the SAI commit <d8d40b4>.
+#define SAI_PACKET_ACTION_DROP 0
+#define SAI_PACKET_ACTION_FORWARD 1
+
 control underlay(
       inout headers_t hdr
     , inout metadata_t meta
@@ -31,6 +36,16 @@ control underlay(
         send_to_port(next_hop_id);
 #endif  // DPDK_PNA_SEND_TO_PORT_FIX_MERGED
 #endif // TARGET_DPDK_PNA  
+    }
+
+    action pkt_act(bit<9> packet_action, bit<9> next_hop_id) {
+        if(packet_action == SAI_PACKET_ACTION_DROP) {
+            /* Drops the packet */
+            meta.dropped = true;
+        } else if (packet_action == SAI_PACKET_ACTION_FORWARD) {
+            /* Forwards the packet on different/same port it arrived based on routing */
+            set_nhop(next_hop_id);
+        }
     }
 
     action def_act() {

--- a/test/test-cases/scale/saic/test_sai_vnet_route_bidirectional.py
+++ b/test/test-cases/scale/saic/test_sai_vnet_route_bidirectional.py
@@ -118,8 +118,7 @@ class TestSaiVnetRoute:
 
         # Verify no packets received
         print("\nVerifying drop...\n")
-        verify_no_other_packets(dataplane)
-
+        assert verify_no_other_packets(dataplane), "Packet are received"
 
         # Route match. send packets from each port, forward and receive packets on opposite ports
         # Send packet one

--- a/test/test-cases/scale/saic/test_sai_vnet_route_bidirectional.py
+++ b/test/test-cases/scale/saic/test_sai_vnet_route_bidirectional.py
@@ -9,11 +9,12 @@ import time
 import pytest
 from saichallenger.common.sai_dataplane.utils.ptf_testutils import (send_packet,
                                                                     simple_udp_packet,
-                                                                    simple_vxlan_packet)
+                                                                    simple_vxlan_packet,
+                                                                    verify_packet,
+                                                                    verify_no_other_packets)
 
 import sys
 sys.path.append("../utils")
-import vnet2vnet_helper as dh
 current_file_dir = Path(__file__).parent
 
 # Constants
@@ -21,112 +22,6 @@ SWITCH_ID = 5
 
 # Simple, non-scaled configuration.
 # See README.md for details.
-
-TEST_VNET_ROUTE_BIDIRECTIONAL_CONFIG = {
-
-    "ENI_COUNT": 1,
-    "ACL_RULES_NSG": 1,
-    "ACL_TABLE_COUNT": 1,
-    "IP_PER_ACL_RULE": 1,
-    "IP_MAPPED_PER_ACL_RULE": 1,
-    "IP_ROUTE_DIVIDER_PER_ACL_RULE": 1,
-
-    'DASH_VIP': {
-        'vpe': {
-            'SWITCH_ID': '$SWITCH_ID',
-            'IPV4': "172.16.1.100"
-        }
-    },
-
-    'DASH_DIRECTION_LOOKUP': {
-        'dle': {
-            'SWITCH_ID': '$SWITCH_ID',
-            'VNI': 100,
-            'ACTION': 'SET_OUTBOUND_DIRECTION'
-        }
-    },
-
-    'DASH_ACL_GROUP': {
-        'in_acl_group_id': {
-            'ADDR_FAMILY': 'IPv4'
-        },
-        'out_acl_group_id': {
-            'ADDR_FAMILY': 'IPv4'
-        }
-    },
-
-    'DASH_VNET': {
-        'vnet': {
-            'VNI': 1000
-        }
-    },
-
-    'DASH_ENI': {
-        'eni': {
-            'ACL_GROUP': {
-                'INBOUND': {
-                    'STAGE1': '$in_acl_group_id_#{0}',
-                    'STAGE2': '$in_acl_group_id_#{0}',
-                    'STAGE3': '$in_acl_group_id_#{0}}',
-                    'STAGE4': '$in_acl_group_id_#{0}}',
-                    'STAGE5': '$in_acl_group_id_#{0}}'
-                },
-                'OUTBOUND': {
-                    'STAGE1': 0,
-                    'STAGE2': 0,
-                    'STAGE3': 0,
-                    'STAGE4': 0,
-                    'STAGE5': 0
-                }
-            },
-            'ADMIN_STATE': True,
-            'CPS': 10000,
-            'FLOWS': 10000,
-            'PPS': 100000,
-            'VM_UNDERLAY_DIP': "172.16.1.1",
-            'VM_VNI': 9,
-            'VNET_ID': '$vnet_#{0}'
-        }
-    },
-
-    'DASH_ENI_ETHER_ADDRESS_MAP': {
-        'eam': {
-            'SWITCH_ID': '$SWITCH_ID',
-            'MAC': "00:cc:cc:cc:00:00",
-            'ENI_ID': '$eni_#{0}'
-        }
-    },
-
-    'DASH_OUTBOUND_ROUTING': {
-        'ore': {
-            'SWITCH_ID': '$SWITCH_ID',
-            'ENI_ID': '$eni_#{0}',
-            'DESTINATION': "10.1.0.0/16",
-            'ACTION': 'ROUTE_VNET',
-            'DST_VNET_ID': '$vnet_#{0}'
-        }
-    },
-
-    'DASH_OUTBOUND_CA_TO_PA': {
-        'ocpe': {
-            'SWITCH_ID': '$SWITCH_ID',
-            'DST_VNET_ID': '$vnet_#{0}',
-            'DIP': "10.1.2.50",
-            'UNDERLAY_DIP': "172.16.1.20",
-            'OVERLAY_DMAC': "00:DD:DD:DD:00:00",
-            'USE_DST_VNET_VNI': True
-        }
-    },
-
-    'DASH_ACL_GROUP': {
-        'in_acl_group_id': {
-            'ADDR_FAMILY': 'IPv4'
-        },
-        'out_acl_group_id': {
-            'ADDR_FAMILY': 'IPv4'
-        }
-    }
-}
 
 @pytest.mark.ptf
 @pytest.mark.snappi
@@ -152,14 +47,82 @@ class TestSaiVnetRoute:
     @pytest.mark.snappi
     def test_vnet_route_packet_bidirectional_forwarding_with_route_match(self, dpu, dataplane):
         """Verify packet forwarding with route match"""
- 
-        """
-        Verify same config with high-rate traffic.
-        packets_per_flow=10 means that each possible packet path will be verified using 10 packet.
-        NOTE: For BMv2 we keep here PPS limitation
-        """
+
         dataplane.set_config()
 
+        # Route match, send packets from each port and drop packets on both ports.
+        # Send packet one
+        inner_pkt_one = simple_udp_packet(eth_dst = "02:02:02:02:02:02",
+                                      eth_src = "00:cc:cc:cc:00:00",
+                                      ip_dst  = "12.1.2.50",
+                                      ip_src  = "10.1.1.10")
+        vxlan_pkt_one = simple_vxlan_packet(eth_dst         = "00:00:02:03:04:05",
+                                        eth_src         = "00:00:05:06:06:06",
+                                        ip_dst          = "170.16.1.100",
+                                        ip_src          = "170.16.1.1",
+                                        udp_sport       = 11638,
+                                        with_udp_chksum = False,
+                                        vxlan_vni       = 100,
+                                        inner_frame     = inner_pkt_one)
+        
+        # Expected received packet one
+        inner_exp_pkt_one = simple_udp_packet(eth_dst = "00:DD:DD:DD:00:00",
+                                          eth_src = "00:cc:cc:cc:00:00",
+                                          ip_dst  = "12.1.2.50",
+                                          ip_src  = "10.1.1.10")
+        vxlan_exp_pkt_one = simple_vxlan_packet(eth_dst         = "00:00:00:00:00:00",
+                                            eth_src         = "00:00:00:00:00:00",
+                                            ip_dst          = "170.16.1.20",
+                                            ip_src          = "170.16.1.100",
+                                            udp_sport       = 0,
+                                            with_udp_chksum = False,
+                                            vxlan_vni       = 100,
+                                            vxlan_flags     = 0,
+                                            inner_frame     = inner_exp_pkt_one)
+        vxlan_exp_pkt_one['IP'].chksum = 0
+
+        # Send packet two
+        inner_pkt_two = simple_udp_packet(eth_dst = "00:00:00:09:03:14",
+                                      eth_src = "00:0a:04:06:06:06",
+                                      ip_dst  = "171.18.1.100",
+                                      ip_src  = "171.18.1.1")
+        vxlan_pkt_two = simple_vxlan_packet(eth_dst         = "00:0b:05:06:06:06",
+                                        eth_src         = "00:0a:05:06:06:06",
+                                        ip_dst          = "10.11.1.20",
+                                        ip_src          = "10.11.1.10",
+                                        udp_sport       = 11639,
+                                        with_udp_chksum = False,
+                                        vxlan_vni       = 100,
+                                        inner_frame     = inner_pkt_two)
+        
+        # Expected received packet two
+        inner_exp_pkt_two = simple_udp_packet(eth_dst = "00:BB:BB:BB:00:00",
+                                          eth_src = "00:0a:04:06:06:06",
+                                          ip_dst  = "171.18.1.100",
+                                          ip_src  = "171.18.1.1")
+        vxlan_exp_pkt_two = simple_vxlan_packet(eth_dst         = "00:00:00:00:00:00",
+                                            eth_src         = "00:00:00:00:00:00",
+                                            ip_dst          = "10.11.1.15",
+                                            ip_src          = "10.11.1.20",
+                                            udp_sport       = 0,
+                                            with_udp_chksum = False,
+                                            vxlan_vni       = 100,
+                                            vxlan_flags     = 0,
+                                            inner_frame     = inner_exp_pkt_two)
+        vxlan_exp_pkt_two['IP'].chksum = 0
+
+        # Send packets from both ports 
+        send_packet(dataplane, 0, vxlan_pkt_one, 10)
+        # time.sleep(0.5)
+        send_packet(dataplane, 1, vxlan_pkt_two, 20)
+
+        # Verify no packets received
+        print("\nVerifying drop...\n")
+        verify_no_other_packets(dataplane)
+
+
+        # Route match. send packets from each port, forward and receive packets on opposite ports
+        # Send packet one
         inner_pkt_one = simple_udp_packet(eth_dst = "02:02:02:02:02:02",
                                       eth_src = "00:cc:cc:cc:00:00",
                                       ip_dst  = "10.1.2.50",
@@ -168,12 +131,28 @@ class TestSaiVnetRoute:
                                         eth_src         = "00:00:05:06:06:06",
                                         ip_dst          = "172.16.1.100",
                                         ip_src          = "172.16.1.1",
-                                        udp_sport       = 11639,
+                                        udp_sport       = 11638,
                                         with_udp_chksum = False,
                                         vxlan_vni       = 100,
                                         inner_frame     = inner_pkt_one)
         
-        # send_packet(dataplane, 1, vxlan_pkt, 111)
+        # Expected received packet one
+        inner_exp_pkt_one = simple_udp_packet(eth_dst = "00:DD:DD:DD:00:00",
+                                          eth_src = "00:cc:cc:cc:00:00",
+                                          ip_dst  = "10.1.2.50",
+                                          ip_src  = "10.1.1.10")
+        vxlan_exp_pkt_one = simple_vxlan_packet(eth_dst         = "00:00:00:00:00:00",
+                                            eth_src         = "00:00:00:00:00:00",
+                                            ip_dst          = "172.16.1.20",
+                                            ip_src          = "172.16.1.100",
+                                            udp_sport       = 0,
+                                            with_udp_chksum = False,
+                                            vxlan_vni       = 100,
+                                            vxlan_flags     = 0,
+                                            inner_frame     = inner_exp_pkt_one)
+        vxlan_exp_pkt_one['IP'].chksum = 0
+
+        # Send packet two
         inner_pkt_two = simple_udp_packet(eth_dst = "00:00:00:09:03:14",
                                       eth_src = "00:0a:04:06:06:06",
                                       ip_dst  = "172.19.1.100",
@@ -182,23 +161,36 @@ class TestSaiVnetRoute:
                                         eth_src         = "00:0a:05:06:06:06",
                                         ip_dst          = "10.10.2.20",
                                         ip_src          = "10.10.2.10",
-                                        udp_sport       = 11638,
+                                        udp_sport       = 11639,
                                         with_udp_chksum = False,
                                         vxlan_vni       = 60,
                                         inner_frame     = inner_pkt_two)
         
-        send_packet(dataplane, 0, vxlan_pkt_one, 111)
-        send_packet(dataplane, 1, vxlan_pkt_two, 777)
+        # Expected received packet two
+        inner_exp_pkt_two = simple_udp_packet(eth_dst = "00:BB:BB:BB:00:00",
+                                          eth_src = "00:0a:04:06:06:06",
+                                          ip_dst  = "172.19.1.100",
+                                          ip_src  = "172.19.1.1")
+        vxlan_exp_pkt_two = simple_vxlan_packet(eth_dst         = "00:00:00:00:00:00",
+                                            eth_src         = "00:00:00:00:00:00",
+                                            ip_dst          = "10.10.2.15",
+                                            ip_src          = "10.10.2.20",
+                                            udp_sport       = 0,
+                                            with_udp_chksum = False,
+                                            vxlan_vni       = 100,
+                                            vxlan_flags     = 0,
+                                            inner_frame     = inner_exp_pkt_two)
+        vxlan_exp_pkt_two['IP'].chksum = 0
 
-        time.sleep(10)
-        rows = dataplane.get_all_stats()
-        print("{}".format(rows[0].name))
-        print("Transmission_Frames : {}".format(rows[0].frames_tx))
-        print("Recieved_Frames : {}".format(rows[0].frames_rx))
-        print("{}".format(rows[1].name))
-        print("--------------------------")
-        print("Transmission_Frames : {}".format(rows[1].frames_tx))
-        print("Recieved_Frames : {}".format(rows[1].frames_rx))
+        # Send packets from both ports 
+        send_packet(dataplane, 0, vxlan_pkt_one, 10)
+        time.sleep(0.5)
+        send_packet(dataplane, 1, vxlan_pkt_two, 20)
+
+        # Verify received packets on specific ports
+        print("\nVerifying packets on both ports...\n")
+        assert verify_packet(dataplane, vxlan_exp_pkt_one, 1), "Packet not received on port 1"
+        assert verify_packet(dataplane, vxlan_exp_pkt_two, 0), "Packet not received on port 0"
 
     @pytest.mark.ptf
     @pytest.mark.snappi

--- a/test/test-cases/scale/saic/test_sai_vnet_route_unidirectional.py
+++ b/test/test-cases/scale/saic/test_sai_vnet_route_unidirectional.py
@@ -205,7 +205,7 @@ class TestSaiVnetRoute:
         send_packet(dataplane, 0, vxlan_pkt, 10)
         time.sleep(0.5)
 
-        # Verify packets from port 1
+        # Verify packets from port 0
         assert verify_packet(dataplane, vxlan_exp_pkt, 0), "Packet not received on port 0"
 
     @pytest.mark.ptf

--- a/test/test-cases/scale/saic/test_sai_vnet_route_unidirectional.py
+++ b/test/test-cases/scale/saic/test_sai_vnet_route_unidirectional.py
@@ -206,7 +206,7 @@ class TestSaiVnetRoute:
         time.sleep(0.5)
 
         # Verify packets from port 1
-        verify_packet(dataplane, vxlan_exp_pkt, 0)
+        assert verify_packet(dataplane, vxlan_exp_pkt, 0), "Packet not received on port 0"
 
     @pytest.mark.ptf
     @pytest.mark.snappi

--- a/test/test-cases/scale/saic/test_sai_vnet_route_unidirectional.py
+++ b/test/test-cases/scale/saic/test_sai_vnet_route_unidirectional.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from pprint import pprint
 import time
 import pytest
+import saichallenger.common.sai_dataplane.snappi.snappi_traffic_utils as stu
 from saichallenger.common.sai_dataplane.utils.ptf_testutils import (send_packet,
                                                                     simple_udp_packet,
                                                                     simple_vxlan_packet,
@@ -153,28 +154,59 @@ class TestSaiVnetRoute:
     @pytest.mark.snappi
     def test_vnet_route_packet_unidirectional_forwarding_with_route_match(self, dpu, dataplane):
         """Verify packet forwarding with route match"""
- 
-        """
-        Verify same config with high-rate traffic.
-        packets_per_flow=10 means that each possible packet path will be verified using 10 packet.
-        NOTE: For BMv2 we keep here PPS limitation
-        """
-        dh.scale_vnet_outbound_flows(dataplane, TEST_VNET_ROUTE_UNIDIRECTIONAL_CONFIG, packets_per_flow=10, pps_per_flow=10)
+
         dataplane.set_config()
-        dataplane.start_traffic()
-        # stu.wait_for(lambda: dh.check_flow_packets_metrics(dataplane, dataplane.flows[0], show=True)[0],
-        #             "Test", timeout_seconds=10)
         
-        time.sleep(10)
-        rows = dataplane.get_all_stats()
-        print("{}".format(rows[0].name))
-        print("--------------------------")
-        print("Tx_Frames : {}".format(rows[0].frames_tx))
-        print("Rx_Frames : {}".format(rows[0].frames_rx))
-        print("{}".format(rows[1].name))
-        print("--------------------------")
-        print("Tx_Frames : {}".format(rows[1].frames_tx))
-        print("Rx_Frames : {}".format(rows[1].frames_rx))
+        # No Route. send packets from a port, reflects the packets on the same port
+        SRC_VM_IP = "10.1.1.10"
+        OUTER_SMAC = "00:00:05:06:06:06"
+        OUR_MAC = "00:00:02:03:04:05"
+
+        VIP = TEST_VNET_ROUTE_UNIDIRECTIONAL_CONFIG['DASH_VIP']['vpe']['IPV4']
+        VNET_VNI = TEST_VNET_ROUTE_UNIDIRECTIONAL_CONFIG['DASH_VNET']['vnet']['VNI']
+        DIR_LOOKUP_VNI = TEST_VNET_ROUTE_UNIDIRECTIONAL_CONFIG['DASH_DIRECTION_LOOKUP']['dle']['VNI']
+        SRC_VM_PA_IP = TEST_VNET_ROUTE_UNIDIRECTIONAL_CONFIG['DASH_ENI']['eni']['VM_UNDERLAY_DIP']
+        ENI_MAC = TEST_VNET_ROUTE_UNIDIRECTIONAL_CONFIG['DASH_ENI_ETHER_ADDRESS_MAP']['eam']['MAC']
+        DST_CA_IP = TEST_VNET_ROUTE_UNIDIRECTIONAL_CONFIG['DASH_OUTBOUND_CA_TO_PA']['ocpe']['DIP']
+        DST_PA_IP = TEST_VNET_ROUTE_UNIDIRECTIONAL_CONFIG['DASH_OUTBOUND_CA_TO_PA']['ocpe']["UNDERLAY_DIP"]
+        DST_CA_MAC = TEST_VNET_ROUTE_UNIDIRECTIONAL_CONFIG['DASH_OUTBOUND_CA_TO_PA']['ocpe']["OVERLAY_DMAC"]
+        
+        # Send packet one
+        inner_pkt = simple_udp_packet(eth_dst = "02:02:02:02:02:02",
+                                      eth_src = ENI_MAC,
+                                      ip_dst  = DST_CA_IP,
+                                      ip_src  = SRC_VM_IP)
+        vxlan_pkt = simple_vxlan_packet(eth_dst         = OUR_MAC,
+                                        eth_src         = OUTER_SMAC,
+                                        ip_dst          = VIP,
+                                        ip_src          = SRC_VM_PA_IP,
+                                        udp_sport       = 11638,
+                                        with_udp_chksum = False,
+                                        vxlan_vni       = DIR_LOOKUP_VNI,
+                                        inner_frame     = inner_pkt)
+
+        # Expected received packet one
+        inner_exp_pkt = simple_udp_packet(eth_dst = DST_CA_MAC,
+                                          eth_src = ENI_MAC,
+                                          ip_dst  = DST_CA_IP,
+                                          ip_src  = SRC_VM_IP)
+        vxlan_exp_pkt = simple_vxlan_packet(eth_dst         = "00:00:00:00:00:00",
+                                            eth_src         = "00:00:00:00:00:00",
+                                            ip_dst          = DST_PA_IP,
+                                            ip_src          = VIP,
+                                            udp_sport       = 0,
+                                            with_udp_chksum = False,
+                                            vxlan_vni       = VNET_VNI,
+                                            vxlan_flags     = 0,
+                                            inner_frame     = inner_exp_pkt)
+        vxlan_exp_pkt['IP'].chksum = 0
+
+        # Send packets from port 0
+        send_packet(dataplane, 0, vxlan_pkt, 10)
+        time.sleep(0.5)
+
+        # Verify packets from port 1
+        verify_packet(dataplane, vxlan_exp_pkt, 0)
 
     @pytest.mark.ptf
     @pytest.mark.snappi

--- a/test/test-cases/scale/saic/vnet_route_setup_commands_bidirectional.json
+++ b/test/test-cases/scale/saic/vnet_route_setup_commands_bidirectional.json
@@ -26,6 +26,32 @@
         ]
     },
     {
+        "name": "vpe_2",
+        "op": "create",
+        "type": "SAI_OBJECT_TYPE_VIP_ENTRY",
+        "key": {
+            "switch_id": "$SWITCH_ID",
+            "vip": "10.11.1.20"
+        },
+        "attributes": [
+            "SAI_VIP_ENTRY_ATTR_ACTION",
+            "SAI_VIP_ENTRY_ACTION_ACCEPT"
+        ]
+    },
+    {
+        "name": "vpe_3",
+        "op": "create",
+        "type": "SAI_OBJECT_TYPE_VIP_ENTRY",
+        "key": {
+            "switch_id": "$SWITCH_ID",
+            "vip": "170.16.1.100"
+        },
+        "attributes": [
+            "SAI_VIP_ENTRY_ATTR_ACTION",
+            "SAI_VIP_ENTRY_ACTION_ACCEPT"
+        ]
+    },
+    {
         "name": "dle",
         "op": "create",
         "type": "SAI_OBJECT_TYPE_DIRECTION_LOOKUP_ENTRY",
@@ -218,6 +244,136 @@
         ]
     },
     {
+        "name": "eni_2",
+        "op": "create",
+        "type": "SAI_OBJECT_TYPE_ENI",
+        "attributes": [
+            "SAI_ENI_ATTR_CPS",
+            "10000",
+            "SAI_ENI_ATTR_PPS",
+            "100000",
+            "SAI_ENI_ATTR_FLOWS",
+            "100000",
+            "SAI_ENI_ATTR_ADMIN_STATE",
+            "True",
+            "SAI_ENI_ATTR_VM_UNDERLAY_DIP",
+            "10.11.1.10",
+            "SAI_ENI_ATTR_VM_VNI",
+            "9",
+            "SAI_ENI_ATTR_VNET_ID",
+            "$vnet",
+            "SAI_ENI_ATTR_INBOUND_V4_STAGE1_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V4_STAGE2_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V4_STAGE3_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V4_STAGE4_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V4_STAGE5_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V6_STAGE1_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V6_STAGE2_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V6_STAGE3_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V6_STAGE4_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V6_STAGE5_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V4_STAGE1_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V4_STAGE2_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V4_STAGE3_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V4_STAGE4_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V4_STAGE5_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V6_STAGE1_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V6_STAGE2_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V6_STAGE3_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V6_STAGE4_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V6_STAGE5_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_V4_METER_POLICY_ID",
+            "0",
+            "SAI_ENI_ATTR_V6_METER_POLICY_ID",
+            "0"
+        ]
+    },
+    {
+        "name": "eni_3",
+        "op": "create",
+        "type": "SAI_OBJECT_TYPE_ENI",
+        "attributes": [
+            "SAI_ENI_ATTR_CPS",
+            "10000",
+            "SAI_ENI_ATTR_PPS",
+            "100000",
+            "SAI_ENI_ATTR_FLOWS",
+            "100000",
+            "SAI_ENI_ATTR_ADMIN_STATE",
+            "True",
+            "SAI_ENI_ATTR_VM_UNDERLAY_DIP",
+            "170.16.1.1",
+            "SAI_ENI_ATTR_VM_VNI",
+            "9",
+            "SAI_ENI_ATTR_VNET_ID",
+            "$vnet",
+            "SAI_ENI_ATTR_INBOUND_V4_STAGE1_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V4_STAGE2_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V4_STAGE3_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V4_STAGE4_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V4_STAGE5_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V6_STAGE1_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V6_STAGE2_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V6_STAGE3_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V6_STAGE4_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_INBOUND_V6_STAGE5_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V4_STAGE1_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V4_STAGE2_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V4_STAGE3_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V4_STAGE4_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V4_STAGE5_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V6_STAGE1_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V6_STAGE2_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V6_STAGE3_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V6_STAGE4_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_OUTBOUND_V6_STAGE5_DASH_ACL_GROUP_ID",
+            "0",
+            "SAI_ENI_ATTR_V4_METER_POLICY_ID",
+            "0",
+            "SAI_ENI_ATTR_V6_METER_POLICY_ID",
+            "0"
+        ]
+    },
+    {
         "name": "eam",
         "op": "create",
         "type": "SAI_OBJECT_TYPE_ENI_ETHER_ADDRESS_MAP_ENTRY",
@@ -328,17 +484,95 @@
         ]
     },
     {
+        "name": "ocpe_2",
+        "op": "create",
+        "type": "SAI_OBJECT_TYPE_OUTBOUND_CA_TO_PA_ENTRY",
+        "key": {
+            "switch_id": "$SWITCH_ID",
+            "dst_vnet_id": "$vnet",
+            "dip": "171.18.1.100"
+        },
+        "attributes": [
+            "SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_UNDERLAY_DIP",
+            "10.11.1.15",
+            "SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_OVERLAY_DMAC",
+            "00:BB:BB:BB:00:00",
+            "SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_USE_DST_VNET_VNI",
+            "True",
+            "SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_METER_CLASS",
+            "0",
+            "SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_METER_CLASS_OVERRIDE",
+            "False"
+        ]
+    },
+    {
+        "name": "ocpe_3",
+        "op": "create",
+        "type": "SAI_OBJECT_TYPE_OUTBOUND_CA_TO_PA_ENTRY",
+        "key": {
+            "switch_id": "$SWITCH_ID",
+            "dst_vnet_id": "$vnet",
+            "dip": "12.1.2.50"
+        },
+        "attributes": [
+            "SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_UNDERLAY_DIP",
+            "170.16.1.20",
+            "SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_OVERLAY_DMAC",
+            "00:DD:DD:DD:00:00",
+            "SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_USE_DST_VNET_VNI",
+            "True",
+            "SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_METER_CLASS",
+            "0",
+            "SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_METER_CLASS_OVERRIDE",
+            "False"
+        ]
+    },
+    {
+        "name": "route_entry_1",
+        "op": "create",
+        "type": "SAI_OBJECT_TYPE_ROUTE_ENTRY",
+        "key": {
+            "switch_id": "$SWITCH_ID",
+            "vr_id": "10",
+            "destination": "10.10.0.20/16"
+        },
+        "attributes": [
+            "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION",
+            "SAI_PACKET_ACTION_FORWARD",
+            "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID",
+            "0"
+        ]
+    },
+    {
+        "name": "route_entry_2",
+        "op": "create",
+        "type": "SAI_OBJECT_TYPE_ROUTE_ENTRY",
+        "key": {
+            "switch_id": "$SWITCH_ID",
+            "vr_id": "10",
+            "destination": "172.0.0.10/8"
+        },
+        "attributes": [
+            "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION",
+            "SAI_PACKET_ACTION_FORWARD",
+            "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID",
+            "1"
+        ]
+    },
+    {
         "name": "route_entry_3",
         "op": "create",
         "type": "SAI_OBJECT_TYPE_ROUTE_ENTRY",
         "key": {
             "switch_id": "$SWITCH_ID",
             "vr_id": "10",
-            "destination": "10.0.0.20/8"
+            "destination": "10.11.0.20/16"
         },
         "attributes": [
+            "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION",
+            "SAI_PACKET_ACTION_DROP",
             "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID",
-            "1"
+            "0"
         ]
     },
     {
@@ -348,11 +582,13 @@
         "key": {
             "switch_id": "$SWITCH_ID",
             "vr_id": "10",
-            "destination": "172.0.0.10/8"
+            "destination": "170.0.0.10/8"
         },
         "attributes": [
+            "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION",
+            "SAI_PACKET_ACTION_DROP",
             "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID",
-            "2"
+            "1"
         ]
     }
 ]

--- a/test/test-cases/scale/saic/vnet_route_setup_commands_unidirectional.json
+++ b/test/test-cases/scale/saic/vnet_route_setup_commands_unidirectional.json
@@ -171,19 +171,5 @@
             "SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_METER_CLASS_OVERRIDE",
             "False"
         ]
-    },
-    {
-        "name": "route_entry_1",
-        "op": "create",
-        "type": "SAI_OBJECT_TYPE_ROUTE_ENTRY",
-        "key": {
-            "switch_id": "$SWITCH_ID",
-            "vr_id": "10",
-            "destination": "0.0.0.0/0"
-        },
-        "attributes": [
-            "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID",
-            "1"
-        ]
     }
 ]


### PR DESCRIPTION
**Description of PR**
This subsequent PR is the continuation of dash_underlay implementation PR #404  in BMv2 of the design mentioned in the dash hld under swss lite.

The focus of this PR is on introducing the implementation of SAI call for "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION" 

The attribute implemented is "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION". In this PR we have added support for packet action types "SAI_PACKET_ACTION_DROP" and "SAI_PACKET_ACTION_FORWARD". 

**Functionality**
In the current implementation, when there is no match in the routing table, the packet continues to be reflected on the same port and when a route is matched in the routing table, the packet is directed to a different port as specified by the matching route.

This PR decides whether to drop or forward the packet first. If the packet is to be forwarded, it goes through the next hop functionality else drops the packet.

**Main Changes**
- Add "packet_action" action to Underlay routing table P4 logic.
- Add VNET API for testing the functionality.

**How did you verify/test it?**
Can run the following test cases successfully:
- test_config_vnet_route_bidirectional.py
- test_config_vnet_route_unidirectional.py